### PR TITLE
Use *.opt toolchain

### DIFF
--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -188,6 +188,11 @@ function buildEjectCommand(
           path = "${allDependencies.map(dep => installPath(dep, 'lib')).join(':')}"
           destdir = "${installPath(packageInfo, 'lib')}"
           ldconf = "ignore"
+          ocamlc = "ocamlc.opt"
+          ocamldep = "ocamldep.opt"
+          ocamldoc = "ocamldoc.opt"
+          ocamllex = "ocamllex.opt"
+          ocamlopt = "ocamlopt.opt"
         `
       });
 


### PR DESCRIPTION
Fixes #11

Test plan:

    % cd tests/TestOne/PackageA/
    % ./test.sh
    % ../../../.bin/esy ocamlfind ocamlopt -verbose

The last command will indicate that `ocamlopt.opt` is used.