### PR TITLE
Do not use node in ejected build script.

### DIFF
--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -124,14 +124,24 @@ function buildEjectCommand(
       let {normalizedName, packageJson} = packageInfo;
       let buildHash = packageInfoKey(sandbox.env, packageInfo);
 
+      let buildCommand: ?string = null;
+      if (packageJson.esy.build != null) {
+        if (Array.isArray(packageJson.esy.build)) {
+          buildCommand = packageJson.esy.build.join(' && ');
+        } else {
+          buildCommand = packageJson.esy.build;
+        }
+      }
+
       function withPackageEnv(command) {
         return outdent`
           export ESY__STORE=$(ESY__STORE); \\
           export ESY__SANDBOX=$(ESY__SANDBOX); \\
           export ESY__RUNTIME=$(ESY__RUNTIME); \\
+          $(${packageEnv}) \\
           export esy_build__source="${packageInfo.source}"; \\
           export esy_build__source_type="${packageInfo.sourceType}"; \\
-          $(${packageEnv}) \\
+          export esy_build__command="${buildCommand || 'true'}"; \\
           cd $cur__source_root; \\
           ${command}
         `

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -7,12 +7,6 @@ FG_GREEN='\033[0;32m'
 FG_WHITE='\033[1;37m'
 FG_RESET='\033[0m'
 
-ESY__BUILD_COMMAND="
-let esy = require(\"$cur__root/package.json\").esy || {};
-let build = esy.build || 'true';
-build = Array.isArray(build) ? build.join(' && ') : build;
-build;"
-
 ESY__SANDBOX_COMMAND=""
 
 if [[ "$esy__platform" == "darwin" ]]; then
@@ -47,12 +41,11 @@ esy-shell () {
 esy-build-command () {
   echo -e "${FG_WHITE}*** $cur__name: building from source...${FG_RESET}"
   BUILD_LOG="$cur__target_dir/_esy_build.log"
-  BUILD_CMD=`node -p "$ESY__BUILD_COMMAND"`
   set +e
   $ESY__SANDBOX_COMMAND /bin/bash   \
     --noprofile --norc              \
     -e -u -o pipefail               \
-    -c "$BUILD_CMD"                 \
+    -c "$esy_build__command"        \
     > "$BUILD_LOG" 2>&1
   BUILD_RETURN_CODE="$?"
   set -e


### PR DESCRIPTION
Previously we used node to get the build command out of package.json, now we pass the build command as env var.

This also fixes Linux test run.
