### PR TITLE
Transactional build

### DIFF
--- a/lib/PackageEnvironment.js
+++ b/lib/PackageEnvironment.js
@@ -164,7 +164,6 @@ var validatePackageJsonExportedEnvVar = (envVar, config, inPackageName, envVarCo
 
 function builtInsPerPackage(
   sandbox: Sandbox,
-  targetPath,
   prefix: string,
   packageInfo: PackageInfo
 ) {
@@ -283,7 +282,6 @@ function addEnvConfigForPackage(
 
 function computeEnvVarsForPackage(
   sandbox: Sandbox,
-  targetPath,
   packageInfo: PackageInfo
 ) {
   let {rootDirectory, packageJson, normalizedName} = packageInfo;
@@ -293,7 +291,6 @@ function computeEnvVarsForPackage(
   let errors = [];
   var autoExportedEnvVarsForPackage = builtInsPerPackage(
     sandbox,
-    targetPath,
     envVarConfigPrefix,
     packageInfo
   );
@@ -353,8 +350,17 @@ function computeEnvVarsForPackage(
   })
 }
 
+function targetPath(sandbox, packageInfo, tree: '_install' | '_build', ...path) {
+  let packageName = packageInfo.packageJson.name;
+  let packageKey = packageInfoKey(sandbox.env, packageInfo);
+  let isRootPackage = packageName === sandbox.packageInfo.packageJson.name;
+  if (isRootPackage) {
+    return ['$esy__sandbox', tree, ...path].join('/');
+  }
+  return ['$esy__store', tree, packageKey, ...path].join('/');
+}
+
 type PackageEnvironmentOptions = {
-  buildInStore?: boolean;
   buildsInSource?: boolean;
 };
 
@@ -366,7 +372,7 @@ function calculateEnvironment(
   sandbox: Sandbox,
   packageInfo: PackageInfo,
   options: PackageEnvironmentOptions = {
-    buildInStore: true,
+    buildsInSource: false,
   }
 ): Environment {
   /**
@@ -377,18 +383,6 @@ function calculateEnvironment(
   let curRootPackageJsonOnEjectingHost = packageInfo.rootDirectory;
   let currentlyBuildingPackageRoot = path.dirname(curRootPackageJsonOnEjectingHost);
   globalSeenVars = {};
-
-  function targetPath(sandbox, packageInfo, tree: '_install' | '_build', ...path) {
-    let packageName = packageInfo.packageJson.name;
-    let packageKey = packageInfoKey(sandbox.env, packageInfo);
-    let isRootPackage = packageName === sandbox.packageInfo.packageJson.name;
-    if (isRootPackage) {
-      return ['$esy__sandbox', tree, ...path].join('/');
-    }
-    return options.buildInStore
-      ? ['$esy__store', tree, packageKey, ...path].join('/')
-      : ['$esy__sandbox', tree, 'node_modules', packageName, ...path].join('/');
-  }
 
   function setUpBuiltinVariables(envConfigState: EnvironmentConfigState) {
     let sandboxExportedEnvVars: {[name: string]: EnvironmentVarExport} = Object.assign(
@@ -414,7 +408,7 @@ function calculateEnvironment(
           __BUILT_IN_DO_NOT_USE_OR_YOU_WILL_BE_PIPd: true,
         },
       },
-      builtInsPerPackage(sandbox, targetPath, 'cur', packageInfo),
+      builtInsPerPackage(sandbox, 'cur', packageInfo),
       {
         'OCAMLFIND_CONF': {
           val: '$cur__target_dir/_esy_findlib.conf',
@@ -499,7 +493,7 @@ function calculateEnvironment(
     }];
     traversePackageDependencyTree(
       packageInfo,
-      computeEnvVarsForPackage.bind(null, sandbox, targetPath)
+      computeEnvVarsForPackage.bind(null, sandbox)
     );
   } catch (err) {
     if (err.code === 'ENOENT') {

--- a/lib/PackageEnvironment.js
+++ b/lib/PackageEnvironment.js
@@ -165,7 +165,8 @@ var validatePackageJsonExportedEnvVar = (envVar, config, inPackageName, envVarCo
 function builtInsPerPackage(
   sandbox: Sandbox,
   prefix: string,
-  packageInfo: PackageInfo
+  packageInfo: PackageInfo,
+  installDirectory?: string
 ) {
   let {
     packageJson: {name, version, esy},
@@ -200,7 +201,9 @@ function builtInsPerPackage(
       targetPath(sandbox, packageInfo, '_build')
     ),
     [`${prefix}__install`]: builtIn(
-      targetPath(sandbox, packageInfo, '_install')
+      installDirectory != null
+        ? installDirectory
+        : targetPath(sandbox, packageInfo, '_install')
     ),
     [`${prefix}__bin`]: builtIn(
       `$${prefix}__install/bin`
@@ -361,7 +364,7 @@ function targetPath(sandbox, packageInfo, tree: '_install' | '_build', ...path) 
 }
 
 type PackageEnvironmentOptions = {
-  buildsInSource?: boolean;
+  installDirectory?: string;
 };
 
 /**
@@ -371,9 +374,7 @@ type PackageEnvironmentOptions = {
 function calculateEnvironment(
   sandbox: Sandbox,
   packageInfo: PackageInfo,
-  options: PackageEnvironmentOptions = {
-    buildsInSource: false,
-  }
+  options: PackageEnvironmentOptions = {}
 ): Environment {
   /**
    * The root package.json path on the "ejecting host" - that is, the host where
@@ -408,7 +409,7 @@ function calculateEnvironment(
           __BUILT_IN_DO_NOT_USE_OR_YOU_WILL_BE_PIPd: true,
         },
       },
-      builtInsPerPackage(sandbox, 'cur', packageInfo),
+      builtInsPerPackage(sandbox, 'cur', packageInfo, options.installDirectory),
       {
         'OCAMLFIND_CONF': {
           val: '$cur__target_dir/_esy_findlib.conf',

--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -33,7 +33,7 @@ function buildEjectCommand(
 
   let sandboxPackageName = sandbox.packageInfo.packageJson.name;
 
-  let sandboxPath = (packageInfo, tree: '_install' | '_build', ...path) => {
+  let sandboxPath = (packageInfo, tree: '_install' | '_build' | '_insttmp', ...path) => {
     let packageName = packageInfo.packageJson.name;
     let packageKey = packageInfoKey(sandbox.env, packageInfo);
     let isRootPackage = packageName === sandbox.packageInfo.packageJson.name;
@@ -58,6 +58,9 @@ function buildEjectCommand(
 
   let installPath = (packageInfo, ...path) =>
     sandboxPath(packageInfo, '_install', ...path);
+
+  let installTmpPath = (packageInfo, ...path) =>
+    sandboxPath(packageInfo, '_insttmp', ...path);
 
   let runtimePath = `$(ESY__STORE)/runtime-${hash(RUNTIME)}.sh`;
 
@@ -104,18 +107,18 @@ function buildEjectCommand(
       type: 'rule',
       target: 'clean',
       phony: true,
-      command: 'rm -rf $(ESY__SANDBOX)/_build $(ESY__SANDBOX)/_install',
+      command: 'rm -rf $(ESY__SANDBOX)/_build $(ESY__SANDBOX)/_install $(ESY__SANDBOX)/_insttmp',
     },
     {
       type: 'rule',
-      target: '$(ESY__STORE)/_install $(ESY__STORE)/_build',
+      target: '$(ESY__STORE)/_install $(ESY__STORE)/_build $(ESY__STORE)/_insttmp',
       command: 'mkdir -p $(@)',
     },
     {
       type: 'rule',
       target: 'esy-store',
       phony: true,
-      dependencies: ['$(ESY__STORE)/_install',  '$(ESY__STORE)/_build'],
+      dependencies: ['$(ESY__STORE)/_install',  '$(ESY__STORE)/_build', '$(ESY__STORE)/_insttmp'],
     },
     {
       type: 'file',
@@ -129,6 +132,7 @@ function buildEjectCommand(
     sandbox.packageInfo,
     (packageInfo) => {
       let {normalizedName, packageJson} = packageInfo;
+      let isRootPackage = packageJson.name === sandboxPackageName;
       let buildHash = packageInfoKey(sandbox.env, packageInfo);
 
       let buildCommand: ?string = null;
@@ -151,6 +155,7 @@ function buildEjectCommand(
           export esy_build__source_type="${packageInfo.sourceType}"; \\
           export esy_build__command="${buildCommand || 'true'}"; \\
           export esy_build__source_root="${sourcePath(packageInfo)}"; \\
+          export esy_build__install="${installPath(packageInfo)}"; \\
           cd $esy_build__source_root; \\
           ${command}
         `
@@ -189,11 +194,10 @@ function buildEjectCommand(
         return `${packageName}.${target}`;
       }
 
-      let isRootPackage = packageJson.name === sandboxPackageName;
-
       let buildEnvironment = PackageEnvironment.calculateEnvironment(
         sandbox,
-        packageInfo
+        packageInfo,
+        {installDirectory: installTmpPath(packageInfo)}
       );
 
       let dependencies = Object
@@ -214,7 +218,7 @@ function buildEjectCommand(
         dependencies: [packageTarget('root')],
         value: outdent`
           path = "${allDependencies.map(dep => installPath(dep, 'lib')).join(':')}"
-          destdir = "${installPath(packageInfo, 'lib')}"
+          destdir = "${installTmpPath(packageInfo, 'lib')}"
           ldconf = "ignore"
           ocamlc = "ocamlc.opt"
           ocamldep = "ocamldep.opt"
@@ -249,7 +253,7 @@ function buildEjectCommand(
             (subpath "$(realpath /tmp)")
             (subpath "$(realpath $(TMPDIR))")
             (subpath "${buildPath(packageInfo)}")
-            (subpath "${installPath(packageInfo)}"))
+            (subpath "${installTmpPath(packageInfo)}"))
         `
       });
 
@@ -258,7 +262,7 @@ function buildEjectCommand(
           type: 'rule',
           target: packageRoot,
           command: withPackageEnv(outdent`
-            if [ ! -d "$cur__install" ]; then \\
+            if [ ! -d "$esy_build__install" ]; then \\
               rm -rf $cur__root; \\
               rsync --quiet --archive $esy_build__source_root/ $cur__root --exclude $cur__root; \\
             fi

--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -28,8 +28,7 @@ const Makefile = require('./Makefile');
 
 function buildEjectCommand(
   sandbox: Sandbox,
-  args: Array<string>,
-  options: {buildInStore?: boolean} = {buildInStore: true}
+  args: Array<string>
 ) {
 
   let sandboxPackageName = sandbox.packageInfo.packageJson.name;
@@ -41,9 +40,7 @@ function buildEjectCommand(
     if (isRootPackage) {
       return ['$(ESY__SANDBOX)', tree, ...path].join('/');
     }
-    return options.buildInStore
-      ? ['$(ESY__STORE)', tree, packageKey, ...path].join('/')
-      : ['$(ESY__SANDBOX)', tree, 'node_modules', packageName, ...path].join('/');
+    return ['$(ESY__STORE)', tree, packageKey, ...path].join('/');
   };
 
   let sourcePath = (packageInfo) => {
@@ -196,8 +193,7 @@ function buildEjectCommand(
 
       let buildEnvironment = PackageEnvironment.calculateEnvironment(
         sandbox,
-        packageInfo,
-        {buildInStore: options.buildInStore}
+        packageInfo
       );
 
       let dependencies = Object

--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -145,6 +145,7 @@ function buildEjectCommand(
 
       function withPackageEnv(command) {
         return outdent`
+          ${process.env.CI ? `export CI="${process.env.CI}";` : ''} \\
           export ESY__STORE=$(ESY__STORE); \\
           export ESY__SANDBOX=$(ESY__SANDBOX); \\
           export ESY__RUNTIME=$(ESY__RUNTIME); \\

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -69,11 +69,19 @@ esy-copy-permissions () {
   chmod `stat -f '%p' "$1"` "${@:2}"
 }
 
+esy-replace-string () {
+  INPUT_FILE="$1"
+  OUTPUT_FILE="$2"
+  SRC_STRING="$3"
+  DEST_STRING="$4"
+  # TODO: This uses bbe command which is not available by default on linux,
+  # darwin at least.
+  bbe -e "s|$SRC_STRING|$DEST_STRING|" -o "$OUTPUT_FILE" "$INPUT_FILE"
+}
+
 esy-commit-install () {
   for filename in `find $cur__install -type f`; do
-    # TODO: This uses bbe command which is not available by default on linux,
-    # darwin at least.
-    bbe -e "s|$cur__install|$esy_build__install|" -o "$filename.rewritten" "$filename"
+    esy-replace-string "$filename" "$filename.rewritten" "$cur__install" "$esy_build__install"
     esy-copy-permissions "$filename" "$filename.rewritten"
     mv "$filename.rewritten" "$filename"
   done

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -70,20 +70,22 @@ esy-copy-permissions () {
 }
 
 esy-replace-string () {
-  INPUT_FILE="$1"
-  OUTPUT_FILE="$2"
-  SRC_STRING="$3"
-  DEST_STRING="$4"
-  # TODO: This uses bbe command which is not available by default on linux,
-  # darwin at least.
-  bbe -e "s|$SRC_STRING|$DEST_STRING|" -o "$OUTPUT_FILE" "$INPUT_FILE"
+  FILE="$1"
+  SRC_STRING="$2"
+  DEST_STRING="$3"
+  # TODO: get rid of python here
+  python -c "
+with open('$FILE', 'r') as input_file:
+  data = input_file.read()
+data = data.replace('$SRC_STRING', '$DEST_STRING')
+with open('$FILE', 'w') as output_file:
+  output_file.write(data)
+  "
 }
 
 esy-commit-install () {
   for filename in `find $cur__install -type f`; do
-    esy-replace-string "$filename" "$filename.rewritten" "$cur__install" "$esy_build__install"
-    esy-copy-permissions "$filename" "$filename.rewritten"
-    mv "$filename.rewritten" "$filename"
+    esy-replace-string "$filename" "$cur__install" "$esy_build__install"
   done
   mv $cur__install $esy_build__install
 }

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -50,7 +50,7 @@ esy-build-command () {
   BUILD_RETURN_CODE="$?"
   set -e
   if [ "$BUILD_RETURN_CODE" != "0" ]; then
-    if [ "$esy_build__source_type" == "local" ]; then
+    if [ "$esy_build__source_type" == "local" ] || [ ! -z "${CI+x}" ] ; then
       echo -e "${FG_RED}*** $cur__name: build failied:\n"
       cat "$BUILD_LOG" | sed  's/^/  /'
       echo -e "${FG_RESET}"


### PR DESCRIPTION
Depends on #25. Fixes #18.

Build into `$prefix/_insttmp` first then mv it into `$prefix/_install`. Not that we `_insttmp` and `_install` has the same length, this is important cause we do path replacement in all files before doing `mv`. This is to fight not relocatable compiler toolchain.