### PR TITLE
Eject build into a directory

### DIFF
--- a/.bin/esy
+++ b/.bin/esy
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -26,20 +28,28 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # Capturing stderr is very important to prevent nodejs from setting
 # stderr to nonblocking mode
 
+EJECT_PATH="$PWD/node_modules/.cache/esy"
+
+esy-eject () {
+  mkdir -p `dirname $EJECT_PATH`
+  rm -rf $EJECT_PATH
+  exec /usr/bin/env node $SCRIPTDIR/esy.js build-eject $EJECT_PATH
+}
+
 if [ "$1" == "build" ] || [ "$1" == "shell" ] || [ "$1" == "clean" ]; then
-  MAKEFILE=`/usr/bin/env node $SCRIPTDIR/esy.js build-eject $CURDIR 2>&1`
+  EJECT_LOG=`esy-eject 2>&1`
   if [ $? -ne 0 ]; then
-    echo "Failed to get dependency:"
-    printf "%s\n" "$MAKEFILE" >&2
+    echo "Failed prepare build environment:"
+    printf "%s\n" "$EJECT_LOG" >&2
     exit 1
   fi
-  make -j -s -f <(echo "$MAKEFILE") "$1"
+  make -j -s -f "$EJECT_PATH/Makefile" "$1"
 
 elif [ "$1" == "build-eject" ]; then
-  exec /usr/bin/env node $SCRIPTDIR/esy.js build-eject $CURDIR
+  esy-eject
 
 else
-  SETENVCMD=$(/usr/bin/env node $SCRIPTDIR/esy.js $CURDIR 2>&1)
+  SETENVCMD=$(/usr/bin/env node $SCRIPTDIR/esy.js 2>&1)
   if [ $? -ne 0 ]; then
     echo "Failed to get dependency:"
     printf "%s\n" "$SETENVCMD" >&2
@@ -50,10 +60,7 @@ else
     export ESY__SANDBOX="$PWD"
   fi
   if [ -z "${ESY__STORE+x}" ]; then
-    export ESY__STORE="$HOME/.esy/store"
-  fi
-  if [ -z "${ESY__RUNTIME+x}" ]; then
-    export ESY__RUNTIME="$HOME/.esy/runtime.sh"
+    export ESY__STORE="$HOME/.esy"
   fi
 
   if [ "$1" != "" ]; then

--- a/.bin/esy
+++ b/.bin/esy
@@ -32,7 +32,7 @@ EJECT_PATH="$PWD/node_modules/.cache/esy"
 
 EJECT_MAKEFILE="
 eject: $EJECT_PATH
-$EJECT_PATH: $PWD/package.json \$(wildcard $PWD/node_modules/*)
+$EJECT_PATH: $PWD/package.json \$(shell find $PWD/node_modules -name 'package.json')
 	rm -rf \$(@)
 	mkdir -p \$(@D)
 	/usr/bin/env node $SCRIPTDIR/esy.js build-eject \$(@)

--- a/.bin/esy
+++ b/.bin/esy
@@ -30,14 +30,20 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 EJECT_PATH="$PWD/node_modules/.cache/esy"
 
-esy-eject () {
-  mkdir -p `dirname $EJECT_PATH`
-  rm -rf $EJECT_PATH
-  exec /usr/bin/env node $SCRIPTDIR/esy.js build-eject $EJECT_PATH
+EJECT_MAKEFILE="
+eject: $EJECT_PATH
+$EJECT_PATH: $PWD/package.json \$(wildcard $PWD/node_modules/*)
+	rm -rf \$(@)
+	mkdir -p \$(@D)
+	/usr/bin/env node $SCRIPTDIR/esy.js build-eject \$(@)
+"
+
+eject () {
+  make -s -f <(echo "$EJECT_MAKEFILE") eject
 }
 
 if [ "$1" == "build" ] || [ "$1" == "shell" ] || [ "$1" == "clean" ]; then
-  EJECT_LOG=`esy-eject 2>&1`
+  EJECT_LOG=`eject 2>&1`
   if [ $? -ne 0 ]; then
     echo "Failed prepare build environment:"
     printf "%s\n" "$EJECT_LOG" >&2
@@ -46,7 +52,7 @@ if [ "$1" == "build" ] || [ "$1" == "shell" ] || [ "$1" == "clean" ]; then
   make -j -s -f "$EJECT_PATH/Makefile" "$1"
 
 elif [ "$1" == "build-eject" ]; then
-  esy-eject
+  eject
 
 else
   SETENVCMD=$(/usr/bin/env node $SCRIPTDIR/esy.js 2>&1)

--- a/.bin/esy.js
+++ b/.bin/esy.js
@@ -141,8 +141,8 @@ const Sandbox = require('../lib/Sandbox');
 
 const builtInCommands = {
   "build-eject": function(...args) {
-    let build = require('../lib/esyBuildEjectCommand');
-    build(...args);
+    let buildEject = require('../lib/esyBuildEjectCommand');
+    buildEject(...args);
   },
 };
 

--- a/lib/Makefile.js
+++ b/lib/Makefile.js
@@ -7,19 +7,24 @@
 
 const outdent = require('outdent');
 
+export type Env = {
+  [name: string]: ?string;
+};
+
 export type MakeRule = {
   type: 'rule';
   target: string;
-  command?: ?string;
+  command?: ?string | Array<void | null | string | Env>;
   phony?: boolean;
   dependencies?: Array<string>;
+  env?: Env;
   exportEnv?: Array<string>;
 };
 
 export type MakeDefine = {
   type: 'define';
   name: string;
-  value: string;
+  value: string | Array<void | null | string | Env>;
 };
 
 export type MakeFile = {
@@ -60,7 +65,7 @@ function renderMakefile(items: Array<MakeItem>) {
 }
 
 function renderMakeDefine({name, value}) {
-  return `define ${name}\n${escapeEnvVar(value)}\nendef`;
+  return `define ${name}\n${escapeEnvVar(renderMakeRuleCommand(value))}\nendef`;
 }
 
 function renderMakeFile({filename, value, target, dependencies = []}) {
@@ -94,6 +99,7 @@ function renderMakeRule(rule) {
     dependencies = [],
     command,
     phony,
+    env,
     exportEnv,
   } = rule;
   let header = `${target}: ${dependencies.join(' ')}`;
@@ -110,16 +116,40 @@ function renderMakeRule(rule) {
   }
 
   if (command != null) {
-    let recipe = escapeEnvVar(renderMakeRuleCommand({command}));
-    return `${prelude}${header}\n${recipe}`;
+    let recipe = escapeEnvVar(renderMakeRuleCommand(command));
+    if (env) {
+      let envString = renderMakeRuleEnv(env);
+      return `${prelude}${header}\n${envString}\\\n${recipe}`;
+    } else {
+      return `${prelude}${header}\n${recipe}`;
+    }
   } else {
     return prelude + header;
   }
 }
 
-function renderMakeRuleCommand({command}) {
-  command = command.split('\n').map(line => `\t${line}`).join('\n');
-  return command;
+function renderMakeRuleEnv(env) {
+  let lines = [];
+  for (let k in env) {
+    if (env[k] != null) {
+      lines.push(`\texport ${k}="${env[k]}";`);
+    }
+  }
+  return lines.join('\\\n');
+}
+
+function renderMakeRuleCommand(command) {
+  if (Array.isArray(command)) {
+    return command
+      .filter(item => item != null)
+      .map(item =>
+        typeof item === 'string'
+        ? renderMakeRuleCommand(item)
+        : renderMakeRuleEnv(item))
+      .join('\\\n');
+  } else {
+    return command.split('\n').map(line => `\t${line};`).join('\\\n');
+  }
 }
 
 function escapeEnvVar(command) {

--- a/lib/PackageEnvironment.js
+++ b/lib/PackageEnvironment.js
@@ -412,7 +412,7 @@ function calculateEnvironment(
       builtInsPerPackage(sandbox, 'cur', packageInfo, options.installDirectory),
       {
         'OCAMLFIND_CONF': {
-          val: '$cur__target_dir/_esy_findlib.conf',
+          val: '$cur__target_dir/_esy/findlib.conf',
           exclusive: false
         },
       }

--- a/lib/esyBuildEjectCommand.js
+++ b/lib/esyBuildEjectCommand.js
@@ -9,6 +9,7 @@ import type {
 } from './Sandbox';
 import type {EnvironmentGroup} from './PackageEnvironment';
 
+const mkdirp = require('mkdirp').sync;
 const childProcess = require('child_process');
 const fs = require('fs');
 const crypto  = require('crypto');
@@ -26,10 +27,29 @@ const {
 const PackageEnvironment = require('./PackageEnvironment');
 const Makefile = require('./Makefile');
 
+const curWorkingDirectory = process.cwd();
+
 function buildEjectCommand(
   sandbox: Sandbox,
   args: Array<string>
 ) {
+
+  let defaultEjectDirectory = path.join(sandbox.packageInfo.rootDirectory, '_esy');
+  let [
+    ejectDirectory = defaultEjectDirectory
+  ] = args;
+
+  function emitFile(file: {filename: Array<string>; contents: string, executable?: boolean}) {
+    let filename = path.join(ejectDirectory, ...file.filename);
+    console.log('ejecting:', path.relative(curWorkingDirectory, filename));
+    mkdirp(path.dirname(filename));
+    fs.writeFileSync(filename, file.contents);
+    if (file.executable) {
+      // $FlowFixMe: fs.constants is not in built-in decls?
+      let mode = fs.constants.S_IRWXU;
+      fs.chmodSync(filename, mode);
+    }
+  }
 
   let sandboxPackageName = sandbox.packageInfo.packageJson.name;
 
@@ -38,18 +58,18 @@ function buildEjectCommand(
     let packageKey = packageInfoKey(sandbox.env, packageInfo);
     let isRootPackage = packageName === sandbox.packageInfo.packageJson.name;
     if (isRootPackage) {
-      return ['$(ESY__SANDBOX)', tree, ...path].join('/');
+      return ['$ESY__SANDBOX', tree, ...path].join('/');
     }
-    return ['$(ESY__STORE)', tree, packageKey, ...path].join('/');
+    return ['$ESY__STORE', tree, packageKey, ...path].join('/');
   };
 
   let sourcePath = (packageInfo) => {
     let isRootPackage = packageInfo.packageJson.name === sandbox.packageInfo.packageJson.name;
     if (isRootPackage) {
-      return '$(ESY__SANDBOX)';
+      return '$ESY__SANDBOX';
     } else {
       let rel = path.relative(sandbox.packageInfo.rootDirectory, packageInfo.rootDirectory);
-      return `$(ESY__SANDBOX)/${rel}`;
+      return `$ESY__SANDBOX/${rel}`;
     }
   };
 
@@ -62,40 +82,44 @@ function buildEjectCommand(
   let installTmpPath = (packageInfo, ...path) =>
     sandboxPath(packageInfo, '_insttmp', ...path);
 
-  let runtimePath = `$(ESY__STORE)/runtime-${hash(RUNTIME)}.sh`;
-
   let prelude: Array<MakeDefine | MakeRawItem> = [
+
     {
       type: 'raw',
       value: `SHELL = ${sandbox.env.SHELL}`,
     },
+
+    // ESY__ROOT is the root directory of the ejected Esy build
+    // environment.
     {
       type: 'raw',
-      value: 'ESY__STORE ?= $(HOME)/.esy/store',
+      value: 'ESY__ROOT := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))'
     },
+
+    // ESY__STORE is the directory where build artifacts should be stored.
     {
       type: 'raw',
-      value: `ESY__RUNTIME ?= ${runtimePath}`
+      value: 'ESY__STORE ?= $(HOME)/.esy',
     },
+
+    // ESY__SANDBOX is the sandbox directory, the directory where the root
+    // package resides.
     {
       type: 'raw',
       value: 'ESY__SANDBOX ?= $(CURDIR)',
     },
+
   ];
 
   let rules: Array<MakeItem> = [
+
+    // These are public API
 
     {
       type: 'rule',
       target: 'build',
       phony: true,
       dependencies: [`${sandboxPackageName}.build`],
-    },
-    {
-      type: 'rule',
-      target: 'rebuild',
-      phony: true,
-      dependencies: [`${sandboxPackageName}.rebuild`],
     },
     {
       type: 'rule',
@@ -109,6 +133,8 @@ function buildEjectCommand(
       phony: true,
       command: 'rm -rf $(ESY__SANDBOX)/_build $(ESY__SANDBOX)/_install $(ESY__SANDBOX)/_insttmp',
     },
+
+    // Create store directory structure
     {
       type: 'rule',
       target: '$(ESY__STORE)/_install $(ESY__STORE)/_build $(ESY__STORE)/_insttmp',
@@ -120,20 +146,18 @@ function buildEjectCommand(
       phony: true,
       dependencies: ['$(ESY__STORE)/_install',  '$(ESY__STORE)/_build', '$(ESY__STORE)/_insttmp'],
     },
-    {
-      type: 'file',
-      target: 'esy-runtime',
-      filename: '$(ESY__RUNTIME)',
-      value: RUNTIME
-    },
   ];
 
   traversePackageDependencyTree(
     sandbox.packageInfo,
     (packageInfo) => {
-      let {normalizedName, packageJson} = packageInfo;
+      let {normalizedName, packageJson, rootDirectory} = packageInfo;
       let isRootPackage = packageJson.name === sandboxPackageName;
       let buildHash = packageInfoKey(sandbox.env, packageInfo);
+
+      let packagePath = isRootPackage
+        ? []
+        : path.relative(sandbox.packageInfo.rootDirectory, rootDirectory).split(path.sep);
 
       let buildCommand: ?string = null;
       if (packageJson.esy.build != null) {
@@ -144,27 +168,10 @@ function buildEjectCommand(
         }
       }
 
-      function withPackageEnv(command) {
-        return outdent`
-          ${process.env.CI ? `export CI="${process.env.CI}";` : ''} \\
-          export ESY__STORE=$(ESY__STORE); \\
-          export ESY__SANDBOX=$(ESY__SANDBOX); \\
-          export ESY__RUNTIME=$(ESY__RUNTIME); \\
-          $(${packageEnv}) \\
-          export esy_build__source="${packageInfo.source}"; \\
-          export esy_build__source_type="${packageInfo.sourceType}"; \\
-          export esy_build__command="${buildCommand || 'true'}"; \\
-          export esy_build__source_root="${sourcePath(packageInfo)}"; \\
-          export esy_build__install="${installPath(packageInfo)}"; \\
-          cd $esy_build__source_root; \\
-          ${command}
-        `
+      function emitPackageFile({filename, contents}) {
+        emitFile({filename: packagePath.concat(filename), contents});
       }
 
-      /**
-       * Produce a package-scoped Makefile rule which executes its command in
-       * the package's environment and working directory.
-       */
       function definePackageRule(rule: {
         target: string;
         dependencies?: Array<string>;
@@ -178,15 +185,15 @@ function buildEjectCommand(
         rules.push({
           type: 'rule',
           target: packageTarget(target),
-          dependencies: ['esy-store', 'esy-runtime', ...dependencies],
+          dependencies: ['esy-store', ...dependencies],
           phony: true,
-          command: command != null
-            ? withPackageEnv(outdent`
-                cd $cur__root; \\
-                source $(ESY__RUNTIME); \\
-                ${command}
-              `)
-            : null
+          command: [
+            outdent`
+              $(shell_env_for__${normalizedName}) source $(ESY__ROOT)/bin/runtime.sh
+              cd $esy_build__source_root
+            `,
+            command,
+          ]
         });
       }
 
@@ -204,19 +211,17 @@ function buildEjectCommand(
         .keys(packageInfo.dependencyTree)
         .map(dep => packageTarget('build', dep));
       let allDependencies = collectTransitiveDependencies(packageInfo);
-      let findlibConf = buildPath(packageInfo, '_esy_findlib.conf');
-      let sandboxConf = buildPath(packageInfo, '_esy_sandbox.sb');
-      let packageRoot = packageInfo.packageJson.esy.buildsInSource
-        ? buildPath(packageInfo)
-        : packageInfo.rootDirectory;
+
       let packageEnv = `${packageJson.name}__env`;
 
-      rules.push({
-        type: 'file',
-        filename: findlibConf,
-        target: packageTarget('findlib.conf'),
-        dependencies: [packageTarget('root')],
-        value: outdent`
+      emitPackageFile({
+        filename: 'env',
+        contents: renderEnv(buildEnvironment),
+      });
+
+      emitPackageFile({
+        filename: 'findlib.conf.in',
+        contents: outdent`
           path = "${allDependencies.map(dep => installPath(dep, 'lib')).join(':')}"
           destdir = "${installTmpPath(packageInfo, 'lib')}"
           ldconf = "ignore"
@@ -236,12 +241,9 @@ function buildEjectCommand(
       // TODO: Try to use (deny default) and pick a set of rules for builds to
       // proceed (it chokes on xcodebuild for now if we disable reading "/" and
       // networking).
-      rules.push({
-        type: 'file',
-        filename: sandboxConf,
-        target: packageTarget('sandbox.sb'),
-        dependencies: [packageTarget('root')],
-        value: outdent`
+      emitPackageFile({
+        filename: 'sandbox.sb.in',
+        contents: outdent`
           (version 1.0)
           (allow default)
 
@@ -251,8 +253,8 @@ function buildEjectCommand(
           (allow file-write*
             (literal "/dev/null")
 
-            (subpath "$(realpath /tmp)")
-            (subpath "$(realpath $(TMPDIR))")
+            (subpath "$TMPDIR_GLOBAL")
+            (subpath "$TMPDIR")
 
             ; cur__root
             ; We don't really need to write into cur__root but some build systems
@@ -272,31 +274,31 @@ function buildEjectCommand(
         `
       });
 
-      if (packageInfo.packageJson.esy.buildsInSource) {
-        rules.push({
-          type: 'rule',
-          target: packageRoot,
-          command: withPackageEnv(outdent`
-            if [ ! -d "$esy_build__install" ]; then \\
-              rm -rf $cur__root; \\
-              rsync --quiet --archive $esy_build__source_root/ $cur__root --exclude $cur__root; \\
-            fi
-          `)
-        });
-        definePackageRule({
-          target: 'root',
-          dependencies: [packageRoot],
-        });
-      } else {
-        definePackageRule({
-          target: 'root',
-        });
-      }
-
       rules.push({
         type: 'define',
-        name: packageEnv,
-        value: renderEnv(buildEnvironment),
+        name: `shell_env_for__${normalizedName}`,
+        value: [
+          {
+            'CI': process.env.CI ? process.env.CI : null,
+            'TMPDIR': '$(TMPDIR)',
+            'ESY__STORE': '$(ESY__STORE)',
+            'ESY__SANDBOX': '$(ESY__SANDBOX)',
+            'ESY__ROOT': '$(ESY__ROOT)',
+          },
+          `source $(ESY__ROOT)/${packagePath.join('/')}/env`,
+          {
+            'esy_build__eject': `$(ESY__ROOT)/${packagePath.join('/')}`,
+            'esy_build__type': packageInfo.packageJson.esy.buildsInSource
+              ? 'in-source'
+              : 'out-of-source',
+            'esy_build__key': buildHash,
+            'esy_build__source': packageInfo.source,
+            'esy_build__source_type': packageInfo.sourceType,
+            'esy_build__command': buildCommand || 'true',
+            'esy_build__source_root': sourcePath(packageInfo),
+            'esy_build__install': installPath(packageInfo),
+          },
+        ],
       });
 
       definePackageRule({
@@ -304,28 +306,86 @@ function buildEjectCommand(
         command: 'esy-clean'
       });
 
-      let buildDependencies = [
-        packageTarget('root'),
-        packageTarget('findlib.conf'),
-        packageTarget('sandbox.sb'),
-        ...dependencies
-      ];
-
       definePackageRule({
         target: 'shell',
-        dependencies: buildDependencies,
+        dependencies,
         command: 'esy-shell'
       });
 
       definePackageRule({
         target: 'build',
-        dependencies: buildDependencies,
-        command: packageInfo.sourceType === 'local' ? 'esy-force-build' : 'esy-build'
+        dependencies,
+        command: 'esy-build'
       });
     });
 
   let allRules = [].concat(prelude).concat(rules);
-  console.log(Makefile.renderMakefile(allRules));
+
+  emitFile({
+    filename: ['bin/render-env'],
+    executable: true,
+    contents: outdent`
+      #!/bin/bash
+
+      # allowed to fail
+      which realpath 2>&1 > /dev/null
+      HAS_REALPATH="$?"
+
+      set -e
+      set -o pipefail
+
+      safe_realpath () {
+        if [ "$HAS_REALPATH" == "0" ]; then
+          realpath "$1"
+        else
+          readlink -f "$1"
+        fi
+      }
+
+      _TMPDIR_GLOBAL=$(safe_realpath "/tmp")
+
+      if [ -d "$TMPDIR" ]; then
+        _TMPDIR=$(safe_realpath "$TMPDIR")
+      else
+        _TMPDIR="/does/not/exist"
+      fi
+
+      sed \\
+        -e "s|\\$ESY__STORE|$ESY__STORE|g"          \\
+        -e "s|\\$ESY__SANDBOX|$ESY__SANDBOX|g"      \\
+        -e "s|\\$TMPDIR_GLOBAL|$_TMPDIR_GLOBAL|g"   \\
+        -e "s|\\$TMPDIR|$_TMPDIR|g"                 \\
+        $1 > $2
+    `
+  });
+
+  emitFile({
+    filename: ['bin/replace-string'],
+    executable: true,
+    contents: outdent`
+      #!/usr/bin/env python
+
+      import sys
+
+      filename, src, dest = sys.argv[1:4]
+
+      with open(filename, 'r') as input_file:
+        data = input_file.read()
+      data = data.replace(src, dest)
+      with open(filename, 'w') as output_file:
+        output_file.write(data)
+    `
+  });
+
+  emitFile({
+    filename: ['bin', 'runtime.sh'],
+    contents: RUNTIME
+  });
+
+  emitFile({
+    filename: ['Makefile'],
+    contents: Makefile.renderMakefile(allRules),
+  });
 }
 
 function hash(value: string): string {
@@ -338,7 +398,7 @@ function renderEnv(groups: Array<EnvironmentGroup>): string {
     .filter(env => env.value != null)
     // $FlowFixMe: make sure env.value is refined above
     .map(env => `export ${env.name}="${env.value}";`)
-    .join('\\\n');
+    .join('\n');
 }
 
 module.exports = buildEjectCommand;

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -19,6 +19,8 @@ fi
 
 _esy-prepare-build-env () {
 
+  rm -rf $cur__install
+
   # prepare build and installation directory
   mkdir -p                \
     $cur__target_dir      \

--- a/lib/esyBuildRuntime.sh
+++ b/lib/esyBuildRuntime.sh
@@ -2,6 +2,10 @@ set -e
 set -u
 set -o pipefail
 
+if [ "$TMPDIR" == "" ]; then
+  unset TMPDIR
+fi
+
 FG_RED='\033[0;31m'
 FG_GREEN='\033[0;32m'
 FG_WHITE='\033[1;37m'
@@ -10,37 +14,43 @@ FG_RESET='\033[0m'
 ESY__SANDBOX_COMMAND=""
 
 if [[ "$esy__platform" == "darwin" ]]; then
-  ESY__SANDBOX_COMMAND="sandbox-exec -f $cur__target_dir/_esy_sandbox.sb"
+  ESY__SANDBOX_COMMAND="sandbox-exec -f $cur__target_dir/_esy/sandbox.sb"
 fi
 
-esy-prepare-install-tree () {
-  mkdir -p $cur__target_dir
-  mkdir -p          \
-    $cur__install   \
-    $cur__lib       \
-    $cur__bin       \
-    $cur__sbin      \
-    $cur__man       \
-    $cur__doc       \
-    $cur__share     \
+_esy-prepare-build-env () {
+
+  # prepare build and installation directory
+  mkdir -p                \
+    $cur__target_dir      \
+    $cur__install         \
+    $cur__lib             \
+    $cur__bin             \
+    $cur__sbin            \
+    $cur__man             \
+    $cur__doc             \
+    $cur__share           \
     $cur__etc
+
+  # for in-source builds copy sources over to build location
+  if [ "$esy_build__type" == "in-source" ]; then
+    rm -rf $cur__root;
+    rsync --quiet --archive $esy_build__source_root/ $cur__root --exclude $cur__root;
+  fi
+
+  mkdir -p $cur__target_dir/_esy
+  $ESY__ROOT/bin/render-env $esy_build__eject/findlib.conf.in $cur__target_dir/_esy/findlib.conf
+  $ESY__ROOT/bin/render-env $esy_build__eject/sandbox.sb.in $cur__target_dir/_esy/sandbox.sb
+
 }
 
-esy-shell () {
-  $ESY__SANDBOX_COMMAND /bin/bash   \
-    --noprofile                     \
-    --rcfile <(echo "
-      export PS1=\"[$cur__name sandbox] $ \";
-      source $ESY__RUNTIME;
-      set +e
-      set +u
-      set +o pipefail
-    ")
-}
+_esy-perform-build () {
 
-esy-build-command () {
+  _esy-prepare-build-env
+
+  cd $cur__root
+
   echo -e "${FG_WHITE}*** $cur__name: building from source...${FG_RESET}"
-  BUILD_LOG="$cur__target_dir/_esy_build.log"
+  BUILD_LOG="$cur__target_dir/_esy/build.log"
   set +e
   $ESY__SANDBOX_COMMAND /bin/bash   \
     --noprofile --norc              \
@@ -60,51 +70,40 @@ esy-build-command () {
     esy-clean
     exit 1
   else
+    for filename in `find $cur__install -type f`; do
+      $ESY__ROOT/bin/replace-string "$filename" "$cur__install" "$esy_build__install"
+    done
+    mv $cur__install $esy_build__install
     echo -e "${FG_GREEN}*** $cur__name: build complete${FG_RESET}"
   fi
 
 }
 
-esy-copy-permissions () {
-  chmod `stat -f '%p' "$1"` "${@:2}"
+esy-build () {
+  if [ "$esy_build__source_type" == "local" ]; then
+    esy-clean
+    _esy-perform-build
+  else
+    if [ ! -d "$esy_build__install" ]; then
+      _esy-perform-build
+    fi
+  fi
 }
 
-esy-replace-string () {
-  FILE="$1"
-  SRC_STRING="$2"
-  DEST_STRING="$3"
-  # TODO: get rid of python here
-  python -c "
-with open('$FILE', 'r') as input_file:
-  data = input_file.read()
-data = data.replace('$SRC_STRING', '$DEST_STRING')
-with open('$FILE', 'w') as output_file:
-  output_file.write(data)
-  "
-}
-
-esy-commit-install () {
-  for filename in `find $cur__install -type f`; do
-    esy-replace-string "$filename" "$cur__install" "$esy_build__install"
-  done
-  mv $cur__install $esy_build__install
+esy-shell () {
+  _esy-prepare-build-env
+  $ESY__SANDBOX_COMMAND /bin/bash   \
+    --noprofile                     \
+    --rcfile <(echo "
+      export PS1=\"[$cur__name sandbox] $ \";
+      source $ESY__ROOT/bin/runtime.sh;
+      set +e
+      set +u
+      set +o pipefail
+      cd $cur__root
+    ")
 }
 
 esy-clean () {
   rm -rf $esy_build__install
-}
-
-esy-build () {
-  if [ ! -d "$esy_build__install" ]; then
-    esy-prepare-install-tree
-    esy-build-command
-    esy-commit-install
-  fi
-}
-
-esy-force-build () {
-  esy-prepare-install-tree
-  esy-build-command
-  esy-clean
-  esy-commit-install
 }

--- a/tests/TestBuildsInSource/__snapshots__/test.js.snap
+++ b/tests/TestBuildsInSource/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 
 # TestBuildsInSource@1.0.0 $esy__sandbox/package.json
 # [BuiltIns]

--- a/tests/TestDepBuildsInSource/__snapshots__/test.js.snap
+++ b/tests/TestDepBuildsInSource/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 export PATH=\"$esy__store/_install/dep-1.0.0/bin:$PATH\"
 export MAN_PATH=\"$esy__store/_install/dep-1.0.0/man:$MAN_PATH\"
 

--- a/tests/TestEnv/__snapshots__/test.js.snap
+++ b/tests/TestEnv/__snapshots__/test.js.snap
@@ -28,7 +28,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 export PATH=\"$esy__store/_install/packageb-1.0.0/bin:$esy__store/_install/packagec-1.0.0/bin:$PATH\"
 export MAN_PATH=\"$esy__store/_install/packageb-1.0.0/man:$esy__store/_install/packagec-1.0.0/man:$MAN_PATH\"
 
@@ -138,7 +138,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 export PATH=\"$esy__store/_install/packagec-1.0.0/bin:$PATH\"
 export MAN_PATH=\"$esy__store/_install/packagec-1.0.0/man:$MAN_PATH\"
 
@@ -224,7 +224,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 
 # PackageC@1.0.0 $esy__sandbox/package.json
 # [BuiltIns]

--- a/tests/TestOCamlCompilation/__snapshots__/test.js.snap
+++ b/tests/TestOCamlCompilation/__snapshots__/test.js.snap
@@ -15,9 +15,9 @@ exports[`test build 1`] = `
 `;
 
 exports[`test build 2`] = `
-"Hello, I'm PackageC!!!!
+"Hello, I\'m PackageC!!!!
 PackageB, PackageB, PackageB
-Hello, I'm PackageA
+Hello, I\'m PackageA
 "
 `;
 
@@ -51,7 +51,7 @@ export cur__toplevel=\"$cur__install/toplevel\"
 export cur__share=\"$cur__install/share\"
 export cur__etc=\"$cur__install/etc\"
 # [Custom Variables]
-export OCAMLFIND_CONF=\"$cur__target_dir/_esy_findlib.conf\"
+export OCAMLFIND_CONF=\"$cur__target_dir/_esy/findlib.conf\"
 export PATH=\"$esy__store/_install/packageb-1.0.0/bin:$esy__store/_install/packagec-1.0.0/bin:$esy__store/_install/buildtool-1.0.0/bin:$esy__store/_install/ocamlfind-1.6.2/bin:$esy__store/_install/ocaml-4.2.3/bin:$PATH\"
 export MAN_PATH=\"$esy__store/_install/packageb-1.0.0/man:$esy__store/_install/packagec-1.0.0/man:$esy__store/_install/buildtool-1.0.0/man:$esy__store/_install/ocamlfind-1.6.2/man:$esy__store/_install/ocaml-4.2.3/man:$MAN_PATH\"
 


### PR DESCRIPTION
Previously we produced a single Makefile and while this was a nice approach unfortunately we hit a ceil, see #28: `Argument list too long` were produced by large dep graphs (try to include core for example).

Now we eject into a directory, `$ESY__SANDBOX/node_modules/.cache/esy` by default.

This directory mirrors the `node_modules` and each package directory contains:
  * `env` - environment to be sourced
  * `findlib.conf.in` - a template for findlib configuration file
  * `sandbox.sb.in` - a template for macOS Seatbelt sandboxing mechanism config

Also we change a structure of global esy store to eliminate `~/.esy/store` and store artifacts directly in `~/.esy` in `_build`, `_install` and `_insttmp`.

Fixes #28 