### PR TITLE
Memoize package resolution using a realpath as a key

### DIFF
--- a/lib/Sandbox.js
+++ b/lib/Sandbox.js
@@ -215,8 +215,8 @@ function buildDependencyTree(
   let dependencyTree: {[name: string]: PackageInfo} = {};
   for (let dependencySpec of dependencySpecList) {
     const {name} = parseDependencySpec(dependencySpec);
-    const dependencyPackageJsonPath  = resolveSync(
-      `${name}/package.json`, {basedir: baseDir});
+    const dependencyPackageJsonPath  = fs.realpathSync(resolveSync(
+      `${name}/package.json`, {basedir: baseDir}));
 
     let packageInfo = context.packageCache.get(dependencyPackageJsonPath);
 


### PR DESCRIPTION
This makes memoization work with package installers which symlink packages form
the global store to installations inside node_modules/.