### PR TITLE
Handle conditionalDependencies

### DIFF
--- a/opam-packages-conversion/bin/config.py
+++ b/opam-packages-conversion/bin/config.py
@@ -25,6 +25,8 @@ ESY_EXTRA_DEP = {
 }
 
 OPAM_DEPOPT_BLACKLIST = {
+    "base-unix",
+    "base-threads",
     "conf-libev",
     "lablgtk",
     "ssl",

--- a/opam-packages-conversion/bin/lib.py
+++ b/opam-packages-conversion/bin/lib.py
@@ -10,18 +10,25 @@ import config
 BOOTSTRAP_OPAM_ENV = """
 #!/usr/bin/env bash
 
-try-enable () {
+try-query-ocamlfind () {
     ocamlfind query "$1" 2>&1 > /dev/null
 
     if [ "$?" -ne 0 ]; then
-        echo "disable"
+        echo "false"
     else
-        echo "enable"
+        echo "true"
     fi
 }
 
-export base_unix_enable=`try-enable unix`
-export base_threads_enable=`try-enable threads`
+if [ `try-query-ocamlfind unix` == "true" ]; then
+    export base_unix_enable="enable"
+    export base_unix_installed="true"
+fi
+
+if [ `try-query-ocamlfind threads` == "true" ]; then
+    export base_threads_enable="enable"
+    export base_threads_installed="true"
+fi
 """.strip()
 
 def generate_package_json(name, version, directory):

--- a/opam-packages-conversion/bin/lib.py
+++ b/opam-packages-conversion/bin/lib.py
@@ -267,7 +267,7 @@ def generate_package_json(name, version, directory):
         if dep == "" or dep in config.OPAM_DEPOPT_BLACKLIST:
             continue
         npm_range = opamRangeToNpmRange(range)
-        packageJSON["dependencies"][scoped(dep)] = npm_range
+        packageJSON.setdefault('conditionalDependencies', {})[scoped(dep)] = npm_range
 
     g = re.findall(r"ocaml-version ([!=<>]+.*?\".*?\")", d["available"])
     if g:

--- a/opam-packages-conversion/convertedPackages.txt
+++ b/opam-packages-conversion/convertedPackages.txt
@@ -3,8 +3,6 @@
 ./forks/ocamlfind esy/1.7.1 origin/master
 
 # Direct convertation
-base-threads base
-base-unix base
 base-bytes base
 biniou 1.0.9
 camomile 0.8.5
@@ -209,8 +207,6 @@ base-bytes base
 base-metaocaml-ocamlfind base
 base-no-ppx base
 base-ocamlbuild base
-base-threads base
-base-unix base
 base 0.1.alpha1
 base58 0.1.2
 base64 1.0.0 1.1.0 2.0.0 2.1.2

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "opam-packages/"
   ],
   "dependencies": {
-    "@andreypopp/pnpm": "^0.50.0",
+    "@andreypopp/pnpm": "^0.51.1",
     "bole": "^3.0.2",
     "chalk": "^1.1.3",
     "execa": "^0.6.0",

--- a/src/Makefile.js
+++ b/src/Makefile.js
@@ -8,7 +8,7 @@
 const outdent = require('outdent');
 
 export type Env = {
-  [name: string]: ?string;
+  [name: string]: ?string | {value: ?string; disableExpand?: boolean};
 };
 
 export type MakeRule = {
@@ -134,11 +134,24 @@ function renderMakeRule(rule) {
   }
 }
 
-function renderMakeRuleEnv(env) {
-  let lines = [];
+function renderMakeRuleEnv(env: ?Env) {
+  const lines = [];
   for (let k in env) {
-    if (env[k] != null) {
-      lines.push(`\texport ${k}="${env[k]}";`);
+    let item = env[k];
+    if (item == null) {
+      continue;
+    }
+    if (typeof item === 'string') {
+      item = {value: item, disableExpand: false};
+    }
+    const {value, disableExpand} = item;
+    if (value == null) {
+      continue;
+    }
+    if (disableExpand) {
+      lines.push(`\texport ${k}='${value}';`);
+    } else {
+      lines.push(`\texport ${k}="${value}";`);
     }
   }
   return lines.join('\\\n');

--- a/src/Sandbox.js
+++ b/src/Sandbox.js
@@ -393,7 +393,7 @@ function formatMissingPackagesError(missingPackages, context) {
     : '';
   return outdent`
     Cannot resolve ${packagesMessage}${extraPackagesMessage} packages
-      At ${context.packageDependencyTrace.join(' -> ')}
+      at ${context.packageDependencyTrace.map(p => p.name).join(' -> ')}
       Did you forget to run "esy install" command?
   `
 }
@@ -401,7 +401,7 @@ function formatMissingPackagesError(missingPackages, context) {
 function formatCircularDependenciesError(dependency, context) {
   return outdent`
     Circular dependency "${dependency} detected
-      At ${context.packageDependencyTrace.join(' -> ')}
+      at ${context.packageDependencyTrace.map(p => p.name).join(' -> ')}
   `
 }
 

--- a/src/buildEjectCommand/index.js
+++ b/src/buildEjectCommand/index.js
@@ -314,7 +314,10 @@ function buildEjectCommand(
             'esy_build__key': buildHash,
             'esy_build__source': packageInfo.source,
             'esy_build__source_type': packageInfo.sourceType,
-            'esy_build__command': buildCommand || 'true',
+            'esy_build__command': {
+              value: buildCommand || 'true',
+              disableExpand: true
+            },
             'esy_build__source_root': sourcePath(packageInfo),
             'esy_build__install': installPath(packageInfo),
           },
@@ -429,8 +432,7 @@ function renderEnv(groups: Array<EnvironmentGroup>): string {
   let env = flattenArray(groups.map(group => group.envVars));
   return env
     .filter(env => env.value != null)
-    // $FlowFixMe: make sure env.value is refined above
-    .map(env => `export ${env.name}="${env.value}";`)
+    .map(env => `export ${env.name}="${(env.value: any)}";`)
     .join('\n');
 }
 

--- a/src/installCommand/index.js
+++ b/src/installCommand/index.js
@@ -159,8 +159,11 @@ async function applyPatch(packageJson: PackageJson, target: string) {
 
 async function putFiles(packageJson: PackageJson, target: string) {
   if (packageJson.opam.files) {
-    await Promise.all(packageJson.opam.files.map(file =>
-      fs.writeFile(path.join(target, file.name), file.content, 'utf8')));
+    await Promise.all(packageJson.opam.files.map(async file => {
+      let filename = path.join(target, file.name);
+      await mkdirp(path.dirname(filename));
+      await fs.writeFile(filename, file.content, 'utf8');
+    }));
   }
 }
 


### PR DESCRIPTION
I propose to add `conditionalDependencies` (`optionalDependencies` name is
already taken by npm and doesn't have the needed mechanics behind it).

The suggestion is to use the same semantics as for `peerDependencies` but not
fail if those packages mentioned in conditionalDependencies are absent from
installation.

If package `optdep` is listed in `conditionalDependencies` for the package `pkg`:

* `optdep` is not being installed automatically (same as with
  `peerDependencies`) for the `pkg`
* Unlike with peerDependencies it is not an error to have no `optdep` installed
  at all.
* If `optdep` is present in the installation (required by some of packages
  above) then it's being pulled into `pkg`'s env.

Fixes #46