### PR TITLE
Cache env so we don't have to spawn node on subsequent invokations

### DIFF
--- a/.bin/esy
+++ b/.bin/esy
@@ -26,11 +26,18 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # Capturing stderr is very important to prevent nodejs from setting
 # stderr to nonblocking mode
 
-EJECT_PATH="$PWD/node_modules/.cache/esy"
-ENV_PATH="$PWD/node_modules/.cache/esy-env"
+if [ -z "${ESY__SANDBOX+x}" ]; then
+  export ESY__SANDBOX="$PWD"
+fi
+if [ -z "${ESY__STORE+x}" ]; then
+  export ESY__STORE="$HOME/.esy"
+fi
 
-if [ -d "$PWD/node_modules" ]; then
-  DEPENDENCIES_PACKAGE_JSON=`find $PWD/node_modules -name 'package.json'`
+EJECT_PATH="$ESY__SANDBOX/node_modules/.cache/esy"
+ENV_PATH="$ESY__SANDBOX/node_modules/.cache/esy-env"
+
+if [ -d "$ESY__SANDBOX/node_modules" ]; then
+  DEPENDENCIES_PACKAGE_JSON=`find $ESY__SANDBOX/node_modules -name 'package.json'`
 else
   DEPENDENCIES_PACKAGE_JSON=""
 fi
@@ -44,7 +51,7 @@ needRebuildTarget () {
     NEED_REBUILD="true"
   else
     # check sandbox package.json
-    if [ "$TARGET" -ot "$PWD/package.json" ]; then
+    if [ "$TARGET" -ot "$ESY__SANDBOX/package.json" ]; then
       NEED_REBUILD="true"
     else
       # check each dependencies' package.json
@@ -79,6 +86,7 @@ builtInEnv () {
       printf "%s\n" "$EJECTED_ENV" >&2
       exit 1
     else
+      mkdir -p `dirname $ENV_PATH`
       echo "$EJECTED_ENV" > "$ENV_PATH"
     fi
   fi
@@ -99,12 +107,6 @@ elif [ "$1" == "install" ] || [ "$1" == "add" ]; then
   builtIn $@
 
 else
-  if [ -z "${ESY__SANDBOX+x}" ]; then
-    export ESY__SANDBOX="$PWD"
-  fi
-  if [ -z "${ESY__STORE+x}" ]; then
-    export ESY__STORE="$HOME/.esy"
-  fi
 
   builtInEnv
 

--- a/.bin/esy
+++ b/.bin/esy
@@ -29,27 +29,59 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 EJECT_PATH="$PWD/node_modules/.cache/esy"
 ENV_PATH="$PWD/node_modules/.cache/esy-env"
 
-EJECT_MAKEFILE="
-DEPS=\$(shell find $PWD/node_modules -name 'package.json')
+if [ -d "$PWD/node_modules" ]; then
+  DEPENDENCIES_PACKAGE_JSON=`find $PWD/node_modules -name 'package.json'`
+else
+  DEPENDENCIES_PACKAGE_JSON=""
+fi
 
-eject: $EJECT_PATH
-$EJECT_PATH: $PWD/package.json \$(DEPS)
-	rm -rf \$(@)
-	mkdir -p \$(@D)
-	/usr/bin/env node $SCRIPTDIR/esy.js build-eject \$(@)
+needRebuildTarget () {
+  TARGET="$1"
+  NEED_REBUILD="false"
 
-env: $ENV_PATH
-$ENV_PATH: $PWD/package.json \$(DEPS)
-	mkdir -p \$(@D)
-	/usr/bin/env node $SCRIPTDIR/esy.js 2>&1 > \$(@)
-"
+  # check if target exist
+  if [ ! -f "$TARGET" ]; then
+    NEED_REBUILD="true"
+  else
+    # check sandbox package.json
+    if [ "$TARGET" -ot "$PWD/package.json" ]; then
+      NEED_REBUILD="true"
+    else
+      # check each dependencies' package.json
+      for dep in $DEPENDENCIES_PACKAGE_JSON; do
+        if [ "$TARGET" -ot "$dep" ]; then
+          NEED_REBUILD="true"
+          break
+        fi
+      done
+    fi
+  fi
+
+  echo "$NEED_REBUILD"
+}
 
 builtInEject () {
-  make -s -f <(echo "$EJECT_MAKEFILE") eject
+  if [ `needRebuildTarget "$EJECT_PATH/Makefile"` == "true" ]; then
+    EJECT_LOG=`node $SCRIPTDIR/esy.js build-eject "$EJECT_PATH" 2>&1`
+    if [ $? -ne 0 ]; then
+      echo "Failed to prepare build environment:"
+      printf "%s\n" "$EJECT_LOG" >&2
+      exit 1
+    fi
+  fi
 }
 
 builtInEnv () {
-  make -s -f <(echo "$EJECT_MAKEFILE") env
+  if [ `needRebuildTarget "$ENV_PATH"` == "true" ]; then
+    EJECTED_ENV=`node $SCRIPTDIR/esy.js 2>&1`
+    if [ $? -ne 0 ]; then
+      echo "Failed to get environment:"
+      printf "%s\n" "$EJECTED_ENV" >&2
+      exit 1
+    else
+      echo "$EJECTED_ENV" > "$ENV_PATH"
+    fi
+  fi
 }
 
 builtIn() {
@@ -57,12 +89,7 @@ builtIn() {
 }
 
 if [ "$1" == "build" ] || [ "$1" == "shell" ] || [ "$1" == "clean" ]; then
-  EJECT_LOG=`builtInEject 2>&1`
-  if [ $? -ne 0 ]; then
-    echo "Failed prepare build environment:"
-    printf "%s\n" "$EJECT_LOG" >&2
-    exit 1
-  fi
+  builtInEject
   make -j -s -f "$EJECT_PATH/Makefile" "$1"
 
 elif [ "$1" == "build-eject" ]; then
@@ -72,19 +99,14 @@ elif [ "$1" == "install" ] || [ "$1" == "add" ]; then
   builtIn $@
 
 else
-  SETENVCMD=`builtInEnv 2>&1`
-  if [ $? -ne 0 ]; then
-    echo "Failed to get environment:"
-    printf "%s\n" "$SETENVCMD" >&2
-    exit 1
-  fi
-
   if [ -z "${ESY__SANDBOX+x}" ]; then
     export ESY__SANDBOX="$PWD"
   fi
   if [ -z "${ESY__STORE+x}" ]; then
     export ESY__STORE="$HOME/.esy"
   fi
+
+  builtInEnv
 
   if [ "$1" != "" ]; then
     source "$ENV_PATH"

--- a/.bin/esy
+++ b/.bin/esy
@@ -27,17 +27,29 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # stderr to nonblocking mode
 
 EJECT_PATH="$PWD/node_modules/.cache/esy"
+ENV_PATH="$PWD/node_modules/.cache/esy-env"
 
 EJECT_MAKEFILE="
+DEPS=\$(shell find $PWD/node_modules -name 'package.json')
+
 eject: $EJECT_PATH
-$EJECT_PATH: $PWD/package.json \$(shell find $PWD/node_modules -name 'package.json')
+$EJECT_PATH: $PWD/package.json \$(DEPS)
 	rm -rf \$(@)
 	mkdir -p \$(@D)
 	/usr/bin/env node $SCRIPTDIR/esy.js build-eject \$(@)
+
+env: $ENV_PATH
+$ENV_PATH: $PWD/package.json \$(DEPS)
+	mkdir -p \$(@D)
+	/usr/bin/env node $SCRIPTDIR/esy.js 2>&1 > \$(@)
 "
 
 builtInEject () {
   make -s -f <(echo "$EJECT_MAKEFILE") eject
+}
+
+builtInEnv () {
+  make -s -f <(echo "$EJECT_MAKEFILE") env
 }
 
 builtIn() {
@@ -60,7 +72,7 @@ elif [ "$1" == "install" ] || [ "$1" == "add" ]; then
   builtIn $@
 
 else
-  SETENVCMD=$(/usr/bin/env node $SCRIPTDIR/esy.js 2>&1)
+  SETENVCMD=`builtInEnv 2>&1`
   if [ $? -ne 0 ]; then
     echo "Failed to get environment:"
     printf "%s\n" "$SETENVCMD" >&2
@@ -75,9 +87,9 @@ else
   fi
 
   if [ "$1" != "" ]; then
-    eval "$SETENVCMD"
+    source "$ENV_PATH"
     exec "$@"
   else
-    echo "$SETENVCMD"
+    cat "$ENV_PATH"
   fi
 fi

--- a/src/installCommand/index.js
+++ b/src/installCommand/index.js
@@ -54,8 +54,9 @@ const OPAM_METADATA_STORE = path.join(__dirname, '..', '..', 'opam-packages');
 const USER_HOME: string = (process.env.HOME: any)
 
 const STORE_PATH = (
-  process.env.ESY__STORE ||
-  path.join(USER_HOME, '.esy', '_fetch')
+  process.env.ESY__STORE != null
+    ?  path.join(process.env.ESY__STORE, '_fetch')
+    :  path.join(USER_HOME, '.esy', '_fetch')
 );
 
 const installationSpec = {


### PR DESCRIPTION
This shaves around 200-300ms from `esy` and `esy CMD` subsequent invokations:
from ~500ms down to ~200ms.

We use the same mechanism to check mtimes as for build-eject caching: make but
probably can do better if we just check mtime manually in bash. This is left
for future improvements though.

*Update:* dropped `make` and rewrote mtime comparison in bash — now it's 100ms less.

```
% time ../esy/.bin/esy true
../esy/.bin/esy true  0.04s user 0.05s system 84% cpu 0.111 total
```