### PR TITLE
clean up some unused await

### DIFF
--- a/src/Sandbox.js
+++ b/src/Sandbox.js
@@ -23,8 +23,7 @@ async function resolve(packageName, baseDirectory): Promise<string> {
 
 async function resolveToRealpath(packageName, baseDirectory) {
   let resolution = await resolve(packageName, baseDirectory);
-  resolution = await fs.realpath(resolution);
-  return resolution;
+  return fs.realpath(resolution);
 }
 
 /**
@@ -137,19 +136,18 @@ async function fromDirectory(directory: string): Promise<Sandbox> {
         resolution = resolveToRealpath(packageName, baseDir);
         resolveCache.set(key, resolution);
       }
-      resolution = await resolution;
       return resolution;
     }
 
     const packageInfoCache: Map<string, Promise<PackageInfo>> = new Map();
 
-    async function buildPackageInfoWithCache(baseDirectory, context) {
+    async function buildPackageInfoWithCache(baseDirectory, context): Promise<PackageInfo> {
       let packageInfo = packageInfoCache.get(baseDirectory);
       if (packageInfo == null) {
         packageInfo = buildPackageInfo(baseDirectory, context);
         packageInfoCache.set(baseDirectory, packageInfo);
       }
-      return await packageInfo;
+      return packageInfo;
     }
 
     const [dependencyTree, errors] = await buildDependencyTree(

--- a/src/installCommand/index.js
+++ b/src/installCommand/index.js
@@ -144,7 +144,7 @@ async function lookupPackageCollection(packageName: string): Promise<PackageJson
     throw new Error(`No package found: @opam/${packageName}`)
   }
 
-  return await readJson(packageRecordFilename);
+  return readJson(packageRecordFilename);
 }
 
 async function fetchFromOpam(target, resolution, fetcher) {


### PR DESCRIPTION
- clean up some unused await
- add return type for buildPackageInfoWithCache

I am really new to async/await (also new to Javascript in whole...), so I maybe totally wrong on this. Based on my understanding if an async function doesn't use the value in a Promise, it can just return that Promise and it will not return a Promise of Promise. I think remove the unused await, make the code litter bit easier to understand.