### PR TITLE
Add quotes around the git URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easy Sandboxes For Compiled Languages
 
 ## Install
 
-npm install -g git://github.com/jordwalke/esy.git#beta-v0.0.2
+`npm install -g "git://github.com/jordwalke/esy.git#beta-v0.0.2"`
 
 ### About
 


### PR DESCRIPTION
Add quotes around the URL because some shells (like zsh) don't like the raw `#`.