### PR TITLE
[Esy] Fix missing opam-alpha conversion point.

### DIFF
--- a/opam-packages-conversion/bin/config.py
+++ b/opam-packages-conversion/bin/config.py
@@ -5,7 +5,6 @@ __dir__ = os.path.dirname(os.path.realpath(__file__))
 os.environ['PATH'] = '%s:%s' % (__dir__, os.environ['PATH'])
 
 GH_ORG_NAME = 'esy-ocaml'
-NPM_SCOPE = 'opam-alpha'
 
 OPAM_PACKAGES = os.path.join(os.path.dirname(__file__), '..', 'opam-repository', 'packages')
 
@@ -54,9 +53,10 @@ def export_caml_ld_library_path(name, stublibs=False):
 
 def caml_ld_library_path(name, stublibs=False):
     norm_name = name.replace('-', '_')
+    # Note that opam_alpha comes from opam-alpha prefix that we use.
     return {
         'scope': 'global',
-        'val': '$opam_%s__lib/%s:$CAML_LD_LIBRARY_PATH' % (
+        'val': '$opam_alpha_%s__lib/%s:$CAML_LD_LIBRARY_PATH' % (
             norm_name,
             'stublibs' if stublibs else name),
     }

--- a/opam-packages-conversion/bin/lib.py
+++ b/opam-packages-conversion/bin/lib.py
@@ -191,7 +191,7 @@ def generate_package_json(name, version, directory):
         return [unescapeBuiltinVariables(cmd) for cmd in build]
 
     def scoped(name):
-        return '@%s/%s' % (config.NPM_SCOPE, name)
+        return '@%s/%s' % ("opam-alpha", name)
 
     def opamVersionToNpmVersion(v):
         v = v.group(0).strip("\"")


### PR DESCRIPTION
Summary: We were using opam_ and we need to use opam_alpha_ for some of
the built in config. I choose to remove the constant config variable
because it gives the illusion that it was the single thing that needs to
be changed in order to change the prefix. This way, I'll make people
grep for it next time they want to change it (and they'll see they have
to make several changes across multiple languages).

Test Plan:

Reviewers:

CC: