### PR TITLE
Make `esy shell` / `esy CMD` use non-pure / loose env

### DIFF
--- a/.bin/esy
+++ b/.bin/esy
@@ -78,7 +78,7 @@ builtInEject () {
   fi
 }
 
-builtInEnv () {
+ensureEnvEjected () {
   if [ `needRebuildTarget "$ENV_PATH"` == "true" ]; then
     EJECTED_ENV=`node $SCRIPTDIR/esy.js 2>&1`
     if [ $? -ne 0 ]; then
@@ -96,19 +96,24 @@ builtIn() {
 	node $SCRIPTDIR/esy.js $@
 }
 
-if [ "$1" == "build" ] || [ "$1" == "shell" ] || [ "$1" == "clean" ]; then
+if [ "$1" == "build" ] || [ "$1" == "build-shell" ] || [ "$1" == "clean" ]; then
   builtInEject
   make -j -s -f "$EJECT_PATH/Makefile" "$1"
 
 elif [ "$1" == "build-eject" ]; then
   builtInEject
 
+elif [ "$1" == "shell" ]; then
+  ensureEnvEjected
+  source "$ENV_PATH"
+  $SHELL
+
 elif [ "$1" == "install" ] || [ "$1" == "add" ]; then
   builtIn $@
 
 else
 
-  builtInEnv
+  ensureEnvEjected
 
   if [ "$1" != "" ]; then
     source "$ENV_PATH"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-env": "^1.1.8",
-    "flow-bin": "^0.38.0",
+    "flow-bin": "^0.39.0",
     "jest": "^18.1.0"
   }
 }

--- a/src/PackageEnvironment.js
+++ b/src/PackageEnvironment.js
@@ -365,6 +365,7 @@ function targetPath(sandbox, packageInfo, tree: '_install' | '_build', ...path) 
 
 type PackageEnvironmentOptions = {
   installDirectory?: string;
+  useLooseEnvironment?: boolean;
 };
 
 /**
@@ -443,7 +444,7 @@ function calculateEnvironment(
       sandbox.packageInfo.rootDirectory,
       "EsySandBox",
       curRootPackageJsonOnEjectingHost,
-      mapObject(sandbox.env, env => ({
+      mapObject(options.useLooseEnvironment ? sandbox.looseEnv : sandbox.env, env => ({
         val: env,
         exclusive: false,
         __BUILT_IN_DO_NOT_USE_OR_YOU_WILL_BE_PIPd: false

--- a/src/Sandbox.js
+++ b/src/Sandbox.js
@@ -48,6 +48,7 @@ async function resolveToRealpath(packageName, baseDirectory) {
  */
 export type Sandbox = {
   env: Environment;
+  looseEnv: Environment;
   packageInfo: PackageInfo;
 };
 
@@ -119,6 +120,9 @@ type SandboxBuildContext = {
 async function fromDirectory(directory: string): Promise<Sandbox> {
   const source = path.resolve(directory);
   const env = getEnvironment();
+  const looseEnv = {...env};
+  delete looseEnv.PATH;
+  delete looseEnv.SHELL;
   const packageJson = await readPackageJson(path.join(directory, 'package.json'));
   const depSpecList = objectToDependencySpecList(
     packageJson.dependencies,
@@ -162,6 +166,7 @@ async function fromDirectory(directory: string): Promise<Sandbox> {
 
     return {
       env,
+      looseEnv,
       packageInfo: {
         source: `local:${await fs.realpath(source)}`,
         sourceType: 'local',
@@ -175,6 +180,7 @@ async function fromDirectory(directory: string): Promise<Sandbox> {
   } else {
     return {
       env,
+      looseEnv,
       packageInfo: {
         source: `local:${await fs.realpath(source)}`,
         sourceType: 'local',

--- a/src/bin/esy.js
+++ b/src/bin/esy.js
@@ -185,7 +185,8 @@ async function main() {
     // the build processes, staleness, package validity etc.
     let envForThisPackageScripts = PackageEnvironment.calculateEnvironment(
       sandbox,
-      sandbox.packageInfo
+      sandbox.packageInfo,
+      {useLooseEnvironment: true}
     );
     console.log(PackageEnvironment.printEnvironment(envForThisPackageScripts));
   } else {

--- a/src/buildEjectCommand/index.js
+++ b/src/buildEjectCommand/index.js
@@ -119,7 +119,7 @@ function buildEjectCommand(
     },
     {
       type: 'rule',
-      target: 'shell',
+      target: 'build-shell',
       phony: true,
       dependencies: [`${sandboxPackageName}.shell`],
     },

--- a/tests/TestBuildsInSource/__snapshots__/test.js.snap
+++ b/tests/TestBuildsInSource/__snapshots__/test.js.snap
@@ -1,8 +1,6 @@
 exports[`test env 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"

--- a/tests/TestDepBuildsInSource/__snapshots__/test.js.snap
+++ b/tests/TestDepBuildsInSource/__snapshots__/test.js.snap
@@ -1,8 +1,6 @@
 exports[`test env 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"

--- a/tests/TestEnv/__snapshots__/test.js.snap
+++ b/tests/TestEnv/__snapshots__/test.js.snap
@@ -1,8 +1,6 @@
 exports[`test environment for PackageA 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"
@@ -111,8 +109,6 @@ export GLOBAL_TEST_VAR_PACKAGEA=\"$packagea__root/package.json\"
 exports[`test environment for PackageB 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"
@@ -197,8 +193,6 @@ export GLOBAL_TEST_VAR_PACKAGEB=\"$packageb__root/package.json\"
 exports[`test environment for PackageC 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"

--- a/tests/TestOCamlCompilation/__snapshots__/test.js.snap
+++ b/tests/TestOCamlCompilation/__snapshots__/test.js.snap
@@ -24,8 +24,6 @@ Hello, I\'m PackageA
 exports[`test env 1`] = `
 "
 # EsySandboxVariables 
-export PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\"
-export SHELL=\"env -i /bin/bash --norc --noprofile\"
 export esy__platform=\"platform\"
 export esy__architecture=\"architecture\"
 export esy__target_platform=\"platform\"


### PR DESCRIPTION
We make `esy shell` and `esy CMD` don't scrab environment. That means that they use pre-existing `$SHELL` and `$PATH`.

To restore the previous behaviour of `esy shell` which is still useful for debugging builds we add `esy build-shell` command.

Fixes #7
Fixes #8

Test plan (for `esy shell`):
* Run `esy install` then `esy build` in Esy enabled project.
* Run `esy shell`
* `which ocaml` should point to sandboxed OCaml `~/.esy/_install/ocaml-HASH/bin/ocaml`
* `env` should include `$TERM`, ... other regular env but augmented with Esy env
* Shell prompt should look identical to the user's shell (before we force `bash`).

Test plan (for `esy CMD`):
* Run `esy install` then `esy build` in Esy enabled project.
* Run `esy vim`
* `:!which ocaml` should point to sandboxed OCaml `~/.esy/_install/ocaml-HASH/bin/ocaml`