### PR TITLE
Make ctypes use a sandboxed version of libffi.

### DIFF
--- a/opam-packages-conversion/bin/config.py
+++ b/opam-packages-conversion/bin/config.py
@@ -26,6 +26,9 @@ ESY_EXTRA_DEP = {
     },
     "conf-pkg-config": {
         "yarn-pkg-config": "reasonml/yarn-pkg-config#esy",
+    },
+    "ctypes": {
+        "libffi": "reasonml/libffi#esy",
     }
 }
 


### PR DESCRIPTION
Title says it all. I tested this locally and it works.